### PR TITLE
Allow Private VPCs to be specified

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,6 +1,9 @@
 version = 1
 
 [[analyzers]]
+name = "terraform"
+
+[[analyzers]]
 name = "secrets"
 
 [[analyzers]]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ module "k8s" {
   default_node_pool_node_count = 1
   default_node_pool_node_size  = "s-2vcpu-2gb"
 
+
   cluster_ipv4_cidr            = "10.1.0.0/20"
 }
 ```
-

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Terraform module which creates a DigitalOcean Kubernetes cluster.
 
 This module is inspired by [terraform-aws-eks](https://github.com/terraform-aws-modules/terraform-aws-eks)
 
-[![DeepSource](https://app.deepsource.com/gh/johncosta/terraform-digitialocean-kubernetes.svg/?label=active+issues&show_trend=true&token=ZtqfwW9-roxIC4Aa8ZyhrmGB)](https://app.deepsource.com/gh/johncosta/terraform-digitialocean-kubernetes/)
+[![DeepSource](https://app.deepsource.com/gh/johncosta/terraform-digitalocean-kubernetes.svg/?label=active+issues&show_trend=true&token=ZtqfwW9-roxIC4Aa8ZyhrmGB)](https://app.deepsource.com/gh/johncosta/terraform-digitalocean-kubernetes/)
 [![GitHub Super-Linter](https://github.com/johncosta/template-repository/actions/workflows/linter.yml/badge.svg)](https://github.com/marketplace/actions/super-linter)
 
 ## Documentation
@@ -23,8 +23,8 @@ This module is inspired by [terraform-aws-eks](https://github.com/terraform-aws-
 
 ```hcl
 module "k8s" {
-  source  = "terraform-digitialocean-kubernetes"
-  version = "0.0.1"
+  source  = "terraform-digitalocean-kubernetes"
+  version = "0.0.3"
 
   cluster_name_prefix          = "test-cluster"
   cluster_region               = "nyc1"
@@ -32,5 +32,8 @@ module "k8s" {
 
   default_node_pool_node_count = 1
   default_node_pool_node_size  = "s-2vcpu-2gb"
+
+  cluster_ipv4_cidr            = "10.1.0.0/20"
 }
 ```
+

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,9 @@
 locals {
   worker_pool_name = join("-", [var.cluster_name_prefix, "default-worker-pool"])
   cluster_name     = join("-", [var.cluster_name_prefix, "cluster"])
+  vpc_name         = join("-", [var.cluster_name_prefix, "vpc"])
+
+  create_vpc = var.cluster_ipv4_cidr != null && var.cluster_ipv4_cidr != ""
 }
 
 data "digitalocean_kubernetes_versions" "version" {
@@ -17,4 +20,17 @@ resource "digitalocean_kubernetes_cluster" "cluster" {
     size       = var.default_node_pool_node_size
     node_count = var.default_node_pool_node_count
   }
+
+  /*
+   * Conditionally set the cluster vpc if a CIDR is passed
+   */
+  vpc_uuid = local.create_vpc ? digitalocean_vpc.vpc.0.id : null
+}
+
+resource "digitalocean_vpc" "vpc" {
+  count = local.create_vpc ? 1 : 0
+
+  name     = local.vpc_name
+  region   = var.cluster_region
+  ip_range = var.cluster_ipv4_cidr
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,6 +2,14 @@ output "cluster_name" {
   value = digitalocean_kubernetes_cluster.cluster.name
 }
 
+output "cluster_id" {
+  value = digitalocean_kubernetes_cluster.cluster.id
+}
+
+output "cluster_urn" {
+  value = digitalocean_kubernetes_cluster.cluster.urn
+}
+
 output "cluster_endpoint" {
   value = digitalocean_kubernetes_cluster.cluster.endpoint
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,13 @@ variable "cluster_region" {
   nullable    = false
 }
 
+variable "cluster_ipv4_cidr" {
+  type        = string
+  description = "k8s cluster ipv4 cidr"
+  nullable    = true
+  default     = null
+}
+
 variable "default_node_pool_node_size" {
   type        = string
   description = "default node pool node size"

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,13 @@ variable "cluster_ipv4_cidr" {
   default     = null
 }
 
+variable "allow_default_vpc" {
+  type        = bool
+  description = "used to explicitly allow default vpc"
+  nullable    = true
+  default     = false
+}
+
 variable "default_node_pool_node_size" {
   type        = string
   description = "default node pool node size"


### PR DESCRIPTION
# Overview

Introduces the capability to set the cluster vpc.  

If new variable `allow_default_vpc` is set to `true`, the cluster will utilize the default vpc for ip addresses. Otherwise, it will take the ipv4 cidr specified in `cluster_ipv4_cidr` and create a new vpc using the block specified, then assign it to the cluster. 

## Checklist
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bugfixes / features)
- [x] Docs have been added / updated (for bugfixes / features)

