### PR TITLE
[GH-11] Integrate argo as an addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This module is inspired by [terraform-aws-eks](https://github.com/terraform-aws-
 ```hcl
 module "k8s" {
   source  = "terraform-digitalocean-kubernetes"
-  version = "0.0.7"
+  version = "0.0.10"
 
   cluster_name_prefix          = "test-cluster"
   cluster_region               = "nyc1"
@@ -38,5 +38,24 @@ module "k8s" {
   # writes the kubeconfig to the local filesystem
   path_to_kubeconfig         = "/full/path/to/.kube"
   use_cluster_name_in_config = true
+
+  cluster_addons = {
+    /*
+     * Add ArgoCD into its own namespace
+     */
+    argo = {
+      enabled = true
+    }
+    /*
+     * Add ingress-nginx and cert-manager into their own namespaces
+     */
+    ingress = {
+      enabled = true
+      config  = {
+        domain_root              = "example.com"
+        domain_certificate_email = "name@example.com"
+      }
+    }
+  }
 }
 ```

--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,10 @@ resource "digitalocean_vpc" "vpc" {
   name     = local.vpc_name
   region   = var.cluster_region
   ip_range = var.cluster_ipv4_cidr
+
+  timeouts {
+    delete = "10m"
+  }
 }
 
 resource "local_sensitive_file" "kubeconfig" {
@@ -51,4 +55,22 @@ resource "local_sensitive_file" "kubeconfig" {
   depends_on = [
     digitalocean_kubernetes_cluster.this
   ]
+}
+
+module "addons" {
+  source = "./modules/addons"
+
+  /*
+   * Pass the cluster name and id to the module to ensure that addons depend on the cluster.
+   */
+  cluster_name   = digitalocean_kubernetes_cluster.this.name
+  cluster_id     = digitalocean_kubernetes_cluster.this.id
+  cluster_addons = var.cluster_addons
+
+  providers = {
+    digitalocean = digitalocean
+    kubernetes   = kubernetes
+    kubectl      = kubectl
+    helm         = helm
+  }
 }

--- a/modules/addons/argo.tf
+++ b/modules/addons/argo.tf
@@ -1,0 +1,61 @@
+locals {
+  argo_addon = lookup(var.cluster_addons, "argo", {
+    enabled = false,
+    config  = {}
+  })
+  argo_enabled       = lookup(local.argo_addon, "enabled", false)
+  argo_name          = lookup(local.argo_addon, "name", "argo")
+  argo_namespace     = lookup(local.argo_addon, "namespace", "argo")
+  argo_chart_config  = lookup(local.argo_addon, "chart_config", {})
+  argo_chart_version = lookup(local.argo_addon, "chart_version", "5.51.6")
+  argo_record_name   = lookup(local.argo_addon, "record_name", "argo")
+  argo_module_config = lookup(local.argo_addon, "config", {
+    subdomain_create = false
+  })
+  argo_subdomain_create = lookup(local.argo_module_config, "subdomain_create", false)
+
+  argo_hostname = join(".", [local.argo_record_name, local.dns_domain_root])
+}
+
+################################################################################
+# Namespace
+################################################################################
+
+resource "kubernetes_namespace" "argo" {
+  count = local.argo_enabled ? 1 : 0
+
+  metadata {
+    name = local.argo_namespace
+  }
+
+  depends_on = [
+    kubernetes_namespace.cert-manager,
+  ]
+}
+
+################################################################################
+# Helm
+################################################################################
+
+resource "helm_release" "argo" {
+  count = local.argo_enabled ? 1 : 0
+
+  name       = local.argo_name
+  namespace  = local.argo_namespace
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argo-cd"
+  version    = local.argo_chart_version
+
+  dynamic "set" {
+    for_each = local.argo_chart_config
+
+    content {
+      name  = set.key
+      value = set.value
+    }
+  }
+
+  depends_on = [
+    kubernetes_namespace.argo,
+  ]
+}

--- a/modules/addons/cert-manager.tf
+++ b/modules/addons/cert-manager.tf
@@ -1,0 +1,117 @@
+locals {
+  cert_manager_addon = lookup(local.nginx_addon, "cert-manager", {
+    enabled   = false,
+    name      = "cert-manager",
+    namespace = "cert-manager",
+    chart_config = {
+      installCRDs = true
+    },
+    chart_version = "1.5.3",
+    module_config = {},
+  })
+  cert_manager_enabled       = lookup(local.cert_manager_addon, "enabled", false) # tflint-ignore: terraform_unused_declarations
+  cert_manager_name          = lookup(local.cert_manager_addon, "name", "cert-manager")
+  cert_manager_namespace     = lookup(local.cert_manager_addon, "namespace", "cert-manager")
+  cert_manager_chart_config  = lookup(local.cert_manager_addon, "chart_config", { installCRDs = true })
+  cert_manager_chart_version = lookup(local.cert_manager_addon, "chart_version", "1.5.3")
+  cert_manager_module_config = lookup(local.cert_manager_addon, "module_config", {}) # tflint-ignore: terraform_unused_declarations
+}
+
+################################################################################
+# Namespace
+################################################################################
+
+resource "kubernetes_namespace" "cert-manager" {
+  count = local.dns_enabled ? 1 : 0
+
+  metadata {
+    name = local.cert_manager_namespace
+  }
+}
+
+################################################################################
+# Helm
+################################################################################
+
+resource "helm_release" "cert-manager" {
+  count = local.dns_enabled ? 1 : 0
+
+  name       = local.cert_manager_name
+  namespace  = local.cert_manager_namespace
+  repository = "https://charts.jetstack.io"
+  chart      = "cert-manager"
+  version    = local.cert_manager_chart_version
+
+  dynamic "set" {
+    for_each = local.cert_manager_chart_config
+
+    content {
+      name  = set.key
+      value = set.value
+    }
+  }
+
+  depends_on = [
+    kubernetes_namespace.cert-manager,
+  ]
+}
+
+################################################################################
+# Issuers
+################################################################################
+
+resource "kubectl_manifest" "letsencrypt-staging" {
+  count     = local.dns_enabled ? 1 : 0
+  yaml_body = <<YAML
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+ name: letsencrypt-staging
+ namespace: cert-manager
+spec:
+ acme:
+   # The ACME server URL
+   server: https://acme-staging-v02.api.letsencrypt.org/directory
+   # Email address used for ACME registration
+   email: ${local.domain_certificate_email}
+   # Name of a secret used to store the ACME account private key
+   privateKeySecretRef:
+     name: letsencrypt-staging
+   # Enable the HTTP-01 challenge provider
+   solvers:
+   - http01:
+       ingress:
+         class:  nginx
+YAML
+  depends_on = [
+    helm_release.cert-manager,
+  ]
+}
+
+resource "kubectl_manifest" "letsencrypt-prod" {
+  count     = local.dns_enabled ? 1 : 0
+  yaml_body = <<YAML
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+  namespace: cert-manager
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-v02.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    email: ${local.domain_certificate_email}
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    # Enable the HTTP-01 challenge provider
+    solvers:
+    - http01:
+        ingress:
+          class: nginx
+YAML
+  depends_on = [
+    helm_release.cert-manager,
+  ]
+}

--- a/modules/addons/ingress.tf
+++ b/modules/addons/ingress.tf
@@ -1,0 +1,86 @@
+locals {
+  nginx_addon = lookup(var.cluster_addons, "ingress", {
+    enabled = false,
+    config = {
+      domain_root              = "example.com",
+      domain_create            = false,
+      domain_certificate_email = "name@example.com"
+    }
+  })
+  nginx_enabled       = lookup(local.nginx_addon, "enabled", false)
+  nginx_name          = lookup(local.nginx_addon, "name", "nginx")
+  nginx_namespace     = lookup(local.nginx_addon, "namespace", "nginx")
+  nginx_chart_version = lookup(local.nginx_addon, "chart_version", "4.9.0")
+  nginx_config = lookup(local.nginx_addon, "config", {
+    domain_root              = "example.com",
+    domain_create            = false,
+    domain_certificate_email = "name@example.com"
+  })
+
+  dns_domain_root          = lookup(local.nginx_config, "domain_root", "example.com")
+  dns_domain_create        = lookup(local.nginx_config, "domain_create", false)
+  domain_certificate_email = lookup(local.nginx_config, "domain_certificate_email", "name@example.com")
+
+  ingress_public_ip_file_path = "/tmp"
+  ingress_public_ip_file      = "nginx_public_ips.txt"
+  full_path_to_public_ip_file = join("/", [local.ingress_public_ip_file_path, local.ingress_public_ip_file])
+}
+
+################################################################################
+# Namespace
+################################################################################
+
+resource "kubernetes_namespace" "nginx" {
+  count = local.nginx_enabled ? 1 : 0
+
+  metadata {
+    name = local.nginx_namespace
+  }
+  depends_on = [
+    kubernetes_namespace.cert-manager,
+    kubernetes_namespace.argo
+  ]
+}
+
+################################################################################
+# Helm
+################################################################################
+
+resource "helm_release" "nginx" {
+  count = local.nginx_enabled ? 1 : 0
+
+  name       = local.nginx_name
+  namespace  = local.nginx_namespace
+  repository = "https://kubernetes.github.io/ingress-nginx"
+  chart      = "ingress-nginx"
+  version    = local.nginx_chart_version
+
+  depends_on = [
+    kubernetes_namespace.nginx,
+  ]
+}
+
+################################################################################
+# External IP
+################################################################################
+
+resource "null_resource" "get-nginx-public-ip" {
+  count = local.nginx_enabled && local.dns_enabled ? 1 : 0
+
+  triggers = { always_run = timestamp() }
+  provisioner "local-exec" {
+    command = "kubectl get svc nginx-ingress-nginx-controller -n nginx --output jsonpath='{.status.loadBalancer.ingress[0].ip}' > ${local.full_path_to_public_ip_file}"
+  }
+  depends_on = [
+    helm_release.nginx,
+  ]
+}
+
+data "local_file" "nginx-public-ip" {
+  count = local.nginx_enabled && local.dns_enabled ? 1 : 0
+
+  filename = local.full_path_to_public_ip_file
+  depends_on = [
+    null_resource.get-nginx-public-ip,
+  ]
+}

--- a/modules/addons/main.tf
+++ b/modules/addons/main.tf
@@ -1,0 +1,83 @@
+locals {
+  dns_enabled = alltrue([
+    local.argo_enabled,
+    local.nginx_enabled,
+    local.dns_domain_root != null,
+  local.dns_domain_root != ""])
+}
+
+################################################################################
+# Ingress
+################################################################################
+
+resource "kubectl_manifest" "argo-ingress" {
+  count = local.dns_enabled ? 1 : 0
+
+  yaml_body = <<YAML
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argo-ingress
+  namespace: ${local.argo_namespace}
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+spec:
+  tls:
+  - hosts:
+    - ${local.argo_hostname}
+    secretName: argo-tls
+  ingressClassName: nginx
+  rules:
+  - host: ${local.argo_hostname}
+    http:
+        paths:
+        - pathType: Prefix
+          path: "/"
+          backend:
+            service:
+              name: argo-argocd-server
+              port:
+                name: https
+YAML
+
+  depends_on = [
+    kubernetes_namespace.argo,
+    kubernetes_namespace.cert-manager
+  ]
+}
+
+################################################################################
+# DNS
+################################################################################
+
+resource "digitalocean_domain" "root" {
+  count = local.dns_domain_create ? 1 : 0
+
+  name       = local.dns_domain_root
+  ip_address = data.local_file.nginx-public-ip[0].content
+}
+
+data "digitalocean_domain" "root" {
+  count = local.dns_domain_create ? 0 : 1
+
+  name = local.dns_domain_root
+}
+
+locals {
+  domain_id = local.dns_domain_create ? digitalocean_domain.root[0].id : data.digitalocean_domain.root[0].id
+}
+resource "digitalocean_record" "www" {
+  count = local.dns_enabled && local.argo_subdomain_create ? 1 : 0
+
+  domain = local.domain_id
+  type   = "A"
+  name   = local.argo_record_name
+  value  = data.local_file.nginx-public-ip[0].content
+
+  depends_on = [
+    kubernetes_namespace.argo,
+  ]
+}

--- a/modules/addons/outputs.tf
+++ b/modules/addons/outputs.tf
@@ -1,0 +1,15 @@
+output "addon_output_argo_config" {
+  value = local.argo_addon
+}
+
+output "nginx_public_ip" {
+  value = try(data.local_file.nginx-public-ip[0].content, "")
+}
+
+output "addon_output_cluster_name" {
+  value = var.cluster_name
+}
+
+output "addon_output_cluster_id" {
+  value = var.cluster_id
+}

--- a/modules/addons/provider.tf
+++ b/modules/addons/provider.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_version = "~> v1.6.0"
+
+  required_providers {
+    digitalocean = {
+      source                = "digitalocean/digitalocean"
+      version               = "~> 2.32.0"
+      configuration_aliases = [digitalocean]
+    }
+    kubernetes = {
+      source                = "hashicorp/kubernetes"
+      version               = "~> 2.24.0"
+      configuration_aliases = [kubernetes]
+    }
+    helm = {
+      source                = "hashicorp/helm"
+      version               = "~> 2.12.1"
+      configuration_aliases = [helm]
+    }
+    kubectl = {
+      source                = "alekc/kubectl"
+      version               = "2.0.4"
+      configuration_aliases = [kubectl]
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "2.4.1"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.2"
+    }
+  }
+}

--- a/modules/addons/variables.tf
+++ b/modules/addons/variables.tf
@@ -1,0 +1,15 @@
+variable "cluster_name" {
+  type        = string
+  description = "Name of the cluster"
+}
+
+variable "cluster_id" {
+  type        = string
+  description = "Id of the cluster"
+}
+
+variable "cluster_addons" {
+  type        = map(any)
+  description = "List of addons to enable"
+  default     = {}
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,6 +2,10 @@ output "cluster_name" {
   value = digitalocean_kubernetes_cluster.this.name
 }
 
+output "cluster_region" {
+  value = digitalocean_kubernetes_cluster.this.region
+}
+
 output "cluster_id" {
   value = digitalocean_kubernetes_cluster.this.id
 }
@@ -26,6 +30,10 @@ output "environment_variable_kubeconfig" {
   value = "export KUBECONFIG=${local.full_path_to_kubeconfig}"
 }
 
-output "cluster_addons" {
+output "input_cluster_addons" {
   value = var.cluster_addons
+}
+
+output "addons_output_argo_config" {
+  value = module.addons.addon_output_argo_config
 }

--- a/provider.tf
+++ b/provider.tf
@@ -3,12 +3,55 @@ terraform {
 
   required_providers {
     digitalocean = {
-      source  = "digitalocean/digitalocean"
-      version = "~> 2.32.0"
+      source                = "digitalocean/digitalocean"
+      version               = "~> 2.32.0"
+      configuration_aliases = [digitalocean]
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.24.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12.1"
+    }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "2.0.4"
     }
     local = {
       source  = "hashicorp/local"
-      version = "~> 2.4.0"
+      version = "2.4.1"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.2"
     }
   }
+}
+
+provider "kubernetes" {
+  host  = digitalocean_kubernetes_cluster.this.endpoint
+  token = digitalocean_kubernetes_cluster.this.kube_config[0].token
+  cluster_ca_certificate = base64decode(
+    digitalocean_kubernetes_cluster.this.kube_config[0].cluster_ca_certificate
+  )
+}
+
+provider "helm" {
+  kubernetes {
+    host  = digitalocean_kubernetes_cluster.this.endpoint
+    token = digitalocean_kubernetes_cluster.this.kube_config[0].token
+    cluster_ca_certificate = base64decode(
+      digitalocean_kubernetes_cluster.this.kube_config[0].cluster_ca_certificate
+    )
+  }
+}
+
+provider "kubectl" {
+  host  = digitalocean_kubernetes_cluster.this.endpoint
+  token = digitalocean_kubernetes_cluster.this.kube_config[0].token
+  cluster_ca_certificate = base64decode(
+    digitalocean_kubernetes_cluster.this.kube_config[0].cluster_ca_certificate
+  )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -56,20 +56,6 @@ variable "use_cluster_name_in_config" {
 }
 
 variable "cluster_addons" {
-  type = map(
-    object({
-      enabled       = bool
-      chart_version = string
-    })
-  )
-  description = <<EOT
-    cluster_addons = {
-      addon =  {
-        enabled = "true"
-        chart_version = "1.0.0"
-      }
-    }
-    EOT
-  nullable    = true
-  default     = null
+  type        = any
+  description = "List of addons to enable"
 }


### PR DESCRIPTION
# Overview

Re-adds argo as an addon to the cluster. Includes cert-manager and ingress to route to the host. 

