### PR TITLE
[GH-27] Add instructions on how to get argo password

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This module is inspired by [terraform-aws-eks](https://github.com/terraform-aws-
 ```hcl
 module "k8s" {
   source  = "terraform-digitalocean-kubernetes"
-  version = "0.0.12"
+  version = "0.1.4"
 
   cluster_name_prefix          = "test"
   cluster_region               = "nyc1"
@@ -69,3 +69,14 @@ module "k8s" {
   }
 }
 ```
+
+### Retrieving ArgoCD Password
+If you're using the ArgoCD addon, you can retrieve the password by running the following command:
+
+```shell
+Run the following command to retrieve the ArgoCD password:
+```shell
+kubectl -n argo get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d
+```
+
+Use `admin` and the password to access the ArgoCD UI.

--- a/modules/addons/argo.tf
+++ b/modules/addons/argo.tf
@@ -9,10 +9,10 @@ locals {
   argo_chart_config  = lookup(local.argo_addon, "chart_config", {})
   argo_chart_version = lookup(local.argo_addon, "chart_version", "5.51.6")
   argo_record_name   = lookup(local.argo_addon, "record_name", "argo")
-  #  argo_module_config = lookup(local.argo_addon, "config", {
-  #    subdomain_create = false
-  #  })
-  //argo_subdomain_create = lookup(local.argo_module_config, "subdomain_create", false)
+  argo_module_config = lookup(local.argo_addon, "config", {
+    subdomain_create = false
+  })
+  argo_subdomain_create = lookup(local.argo_module_config, "subdomain_create", false)
 
   argo_hostname = join(".", [local.argo_record_name, local.dns_domain_root])
 }

--- a/modules/addons/main.tf
+++ b/modules/addons/main.tf
@@ -48,3 +48,22 @@ YAML
     kubernetes_namespace.cert-manager
   ]
 }
+
+data "digitalocean_domain" "root" {
+  count = local.dns_enabled ? 1 : 0
+
+  name = local.dns_domain_root
+}
+
+resource "digitalocean_record" "www" {
+  count = local.dns_enabled && local.argo_subdomain_create ? 1 : 0
+
+  domain = data.digitalocean_domain.root[0].id
+  type   = "A"
+  name   = local.argo_record_name
+  value  = data.local_file.nginx-public-ip[0].content
+
+  depends_on = [
+    kubernetes_namespace.argo,
+  ]
+}


### PR DESCRIPTION
# Overview

Adds instructions on how to get ArgoCD password. Also adds subdomain logic back in. 

## Checklist
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bugfixes / features)
- [x] Docs have been added / updated (for bugfixes / features)

